### PR TITLE
Migrate to Shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </h3>
 
 <p align="center">
-  A library for interacting with the Clubhouse REST API
+  A library for interacting with the Shortcut REST API
 </p>
 
 <p align="center">
@@ -45,24 +45,24 @@ yarn add clubhouse-lib
 
 ### How to Get an API Token
 
-The Clubhouse API uses token-based authentication, you will need one to use this library.
+The Shortcut API uses token-based authentication, you will need one to use this library.
 
-To generate an API token, go to https://app.clubhouse.io/settings/account/api-tokens. To make it easier to explore our API, we recommend saving this token as an environment variable in your local dev environment:
+To generate an API token, go to https://app.shortcut.com/settings/account/api-tokens. To make it easier to explore our API, we recommend saving this token as an environment variable in your local dev environment:
 
 ```bash
-export CLUBHOUSE_API_TOKEN="YOUR API TOKEN HERE"
+export SHORTCUT_API_TOKEN="YOUR API TOKEN HERE"
 ```
 
 This will allow you to copy and paste many examples in the documentation to try them out.
 
-Requests made with a missing or invalid token will get a `401 Unauthorized` response. All requests must be made over HTTPS. Tokens provide complete access to your Clubhouse account, **so keep them secure**. Don’t paste them into your source code, use an environment variable instead. For security reasons, we will immediately invalidate any tokens we find have been made public.
+Requests made with a missing or invalid token will get a `401 Unauthorized` response. All requests must be made over HTTPS. Tokens provide complete access to your Shortcut account, **so keep them secure**. Don’t paste them into your source code, use an environment variable instead. For security reasons, we will immediately invalidate any tokens we find have been made public.
 
 ## Usage
 
 ```javascript
-import Clubhouse from 'clubhouse-lib';
+import Shortcut from 'clubhouse-lib';
 
-const client = Clubhouse.create('your token value'); // See https://github.com/clubhouse/clubhouse-lib#how-to-get-an-api-token
+const client = Shortcut.create('your token value'); // See https://github.com/useshortcut/clubhouse-lib#how-to-get-an-api-token
 
 client.listMembers().then(console.log);
 
@@ -81,4 +81,4 @@ You can play with it in your web browser with this live playground:
 
 ## Documentation
 
-[Documentation for the REST API](https://clubhouse.io/api/rest).
+[Documentation for the REST API](https://shortcut.com/api/rest).

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
   "name": "clubhouse-lib",
   "version": "0.12.0",
-  "description": "A Promise based library to the Clubhouse REST API",
+  "description": "A Promise based library to the Shortcut REST API",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
     "lib"
   ],
   "bugs": {
-    "url": "https://github.com/clubhouse/clubhouse-lib/issues"
+    "url": "https://github.com/useshortcut/clubhouse-lib/issues"
   },
-  "homepage": "https://github.com/clubhouse/clubhouse-lib",
-  "readme": "https://github.com/clubhouse/clubhouse-lib#readme",
+  "homepage": "https://github.com/useshortcut/clubhouse-lib",
+  "readme": "https://github.com/useshortcut/clubhouse-lib#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/clubhouse/clubhouse-lib.git"
+    "url": "https://github.com/useshortcut/clubhouse-lib.git"
   },
   "license": "MIT",
   "scripts": {

--- a/src/__tests__/Client-tests.ts
+++ b/src/__tests__/Client-tests.ts
@@ -9,7 +9,7 @@ describe('#Client', () => {
   });
 
   describe('.listProjects', () => {
-    it('returns a list of projects with a clubhouse account', async () => {
+    it('returns a list of projects with a shortcut account', async () => {
       const requests:
         | any[]
         | { uri: string; method?: string; body?: Record<string, any> }[] = [];

--- a/src/__tests__/TokenRequestFactory-tests.ts
+++ b/src/__tests__/TokenRequestFactory-tests.ts
@@ -5,7 +5,7 @@ describe('TokenRequestFactory', () => {
     it('correctly combines query parameters', () => {
       const factory = new TokenRequestFactory(
         'abc-123',
-        'https://api.clubhouse.io',
+        'https://api.app.shortcut.com',
         'v3',
       );
 
@@ -14,7 +14,7 @@ describe('TokenRequestFactory', () => {
       });
 
       expect(request.url).toEqual(
-        'https://api.clubhouse.io/api/v3/search/stories?token=abc-123&query=project%3Amobile',
+        'https://api.app.shortcut.com/api/v3/search/stories?token=abc-123&query=project%3Amobile',
       );
 
       // $FlowFixMe
@@ -26,7 +26,7 @@ describe('TokenRequestFactory', () => {
     it('correctly combines query parameters', async () => {
       const factory = new TokenRequestFactory(
         'abc-123',
-        'https://api.clubhouse.io',
+        'https://api.app.shortcut.com',
         'v3',
       );
 
@@ -35,7 +35,7 @@ describe('TokenRequestFactory', () => {
       });
 
       expect(request.url).toEqual(
-        'https://api.clubhouse.io/api/v3/search/stories?token=abc-123',
+        'https://api.app.shortcut.com/api/v3/search/stories?token=abc-123',
       );
 
       // $FlowFixMe

--- a/src/__tests__/__snapshots__/Client-tests.ts.snap
+++ b/src/__tests__/__snapshots__/Client-tests.ts.snap
@@ -123,7 +123,7 @@ Array [
 ]
 `;
 
-exports[`#Client .listProjects returns a list of projects with a clubhouse account 1`] = `
+exports[`#Client .listProjects returns a list of projects with a shortcut account 1`] = `
 Array [
   Object {
     "body": undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ import {
 
 export * from './types';
 
-const API_BASE_URL = 'https://api.clubhouse.io';
+const API_BASE_URL = 'https://api.app.shortcut.com';
 const API_VERSION = 'v3';
 
 /** */


### PR DESCRIPTION
#112

Migrates:

- Base url api.clubhouse.io -> api.app.shortcut.com
- References to Clubhouse in tests
- https://github.com/clubhouse -> https://github.com/useshortcut

Does not migrate:

- NPM package (still clubhouse-lib)
- Github repository name (still clubhouse-lib)
- References to clubhouse-lib in continuous integration
- Branding in README (e.g. logo)

^  I didn't migrate tasks on the `does not migrate` list because I didn't think I had permissions to do so. I think it'd make sense to have a Clubhouse employee complete the migration, but I'd be happy to help however I can. Thanks for building and maintaining this project Shortcut team!

