### PR TITLE
Add Shortcut-Token header

### DIFF
--- a/src/TokenRequestFactory.ts
+++ b/src/TokenRequestFactory.ts
@@ -33,9 +33,8 @@ class TokenRequestFactory implements RequestFactory<Request> {
     const headers = {
       Accept: 'application/json',
       'Content-Type': 'application/json; charset=utf-8',
+      'Shortcut-Token': this.token,
     };
-
-    url.searchParams.append('token', this.token);
 
     if (method === 'GET') {
       if (body) {

--- a/src/__tests__/TokenRequestFactory-tests.ts
+++ b/src/__tests__/TokenRequestFactory-tests.ts
@@ -14,7 +14,7 @@ describe('TokenRequestFactory', () => {
       });
 
       expect(request.url).toEqual(
-        'https://api.app.shortcut.com/api/v3/search/stories?token=abc-123&query=project%3Amobile',
+        'https://api.app.shortcut.com/api/v3/search/stories?query=project%3Amobile',
       );
 
       // $FlowFixMe
@@ -35,7 +35,7 @@ describe('TokenRequestFactory', () => {
       });
 
       expect(request.url).toEqual(
-        'https://api.app.shortcut.com/api/v3/search/stories?token=abc-123',
+        'https://api.app.shortcut.com/api/v3/search/stories',
       );
 
       // $FlowFixMe


### PR DESCRIPTION
Passing a token as a query param is deprecated, updating this to use `Shortcut-Token` header instead.